### PR TITLE
Taxonomy nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 /validation.js
 /itemNodes.js
 /typeNodes.js
+/taxonomyNodes.js
 /decorators/languageVariantsDecorator.js
 /decorators/typeItemDecorator.js
 /decorators/richTextElementDecorator.js

--- a/README.md
+++ b/README.md
@@ -351,6 +351,25 @@ All rich text properties with content items linked in the element also have an a
 
 All nodes have a `usedByContentItems` property that reflects the other nodes in which the given node is used as linked content in *Linked items* or *Rich text* elements.
 
+### Taxonomies
+
+Taxonomy groups can be queried similar to content types.  For example, to fetch a taxonomy group called *Categories*, you can query `allKontentTaxonomyCategories`, using the `terms` property to return the values of taxonomy terms.
+
+<details><summary>Example</summary>
+```gql
+{
+  allKontentTaxonomyCategories {
+    nodes {
+      terms {
+        name
+        codename
+      }
+    }
+  }
+}
+```
+</details>
+
 ## Development prerequisites
 
 * [Node.js](https://nodejs.org/) with NPM installed

--- a/README.md
+++ b/README.md
@@ -364,6 +364,10 @@ Taxonomy groups can be queried similar to content types.  For example, to fetch 
         name
         codename
       }
+      system {
+        name
+        codename
+      }
     }
   }
 }

--- a/src/__tests__/__snapshots__/gatsby-node.spec.js.snap
+++ b/src/__tests__/__snapshots__/gatsby-node.spec.js.snap
@@ -1596,6 +1596,66 @@ GraphQL nodes of content items contain the ordinary \`system\` and \`elements\` 
   Array [
     Object {
       "children": Array [],
+      "id": "dummyId",
+      "internal": Object {
+        "contentDigest": "9f77ec1fba818dbbc31676bc96d0bb17",
+        "type": "KontentTaxonomyCategories",
+      },
+      "parent": null,
+      "system": Object {
+        "codename": "categories",
+        "id": "e4c2a7f7-2774-49eb-8d26-2351f646f407",
+        "lastModified": "2019-11-04T16:06:59.9936285Z",
+        "name": "Categories",
+      },
+      "terms": Array [
+        Object {
+          "codename": "article",
+          "name": "Article",
+          "terms": Array [],
+        },
+        Object {
+          "codename": "code",
+          "name": "Code",
+          "terms": Array [],
+        },
+        Object {
+          "codename": "education",
+          "name": "Education",
+          "terms": Array [],
+        },
+      ],
+      "usedByContentItems___NODE": Array [],
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "id": "dummyId",
+      "internal": Object {
+        "contentDigest": "8182400fb81c06e0a030c2abf05621fc",
+        "type": "KontentTaxonomyTags",
+      },
+      "parent": null,
+      "system": Object {
+        "codename": "tags",
+        "id": "45ed7f4f-edb4-4f5c-a929-50ef6c214c10",
+        "lastModified": "2019-10-09T21:09:14.8052879Z",
+        "name": "Tags",
+      },
+      "terms": Array [
+        Object {
+          "codename": "education",
+          "name": "Education",
+          "terms": Array [],
+        },
+      ],
+      "usedByContentItems___NODE": Array [],
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
       "contentType___NODE": "dummyId",
       "elements": Object {
         "text": Object {

--- a/src/__tests__/fakeTaxonomyResponse.json
+++ b/src/__tests__/fakeTaxonomyResponse.json
@@ -1,0 +1,50 @@
+{
+    "taxonomies": [
+        {
+            "system": {
+                "id": "e4c2a7f7-2774-49eb-8d26-2351f646f407",
+                "name": "Categories",
+                "codename": "categories",
+                "last_modified": "2019-11-04T16:06:59.9936285Z"
+            },
+            "terms": [
+                {
+                    "name": "Article",
+                    "codename": "article",
+                    "terms": []
+                },
+                {
+                    "name": "Code",
+                    "codename": "code",
+                    "terms": []
+                },
+                {
+                    "name": "Education",
+                    "codename": "education",
+                    "terms": []
+                }
+            ]
+        },
+        {
+            "system": {
+                "id": "45ed7f4f-edb4-4f5c-a929-50ef6c214c10",
+                "name": "Tags",
+                "codename": "tags",
+                "last_modified": "2019-10-09T21:09:14.8052879Z"
+            },
+            "terms": [
+                {
+                    "name": "Education",
+                    "codename": "education",
+                    "terms": []
+                }
+            ]
+        }
+    ],
+    "pagination": {
+        "skip": 0,
+        "limit": 0,
+        "count": 2,
+        "next_page": ""
+    }
+}

--- a/src/__tests__/gatsby-node.spec.js
+++ b/src/__tests__/gatsby-node.spec.js
@@ -10,6 +10,8 @@ const complexContentItemsSecondtLanguageFakeReponse =
   require('./complexContentItemsSecondLanguageFakeReponse.json');
 const complexTypesFakeResponse =
   require('./complexTypesFakeResponse.json');
+const fakeTaxonomyResponse = 
+  require('./fakeTaxonomyResponse.json');
 
 describe('customTrackingHeader', () => {
   it('has correct name', () => {
@@ -159,6 +161,12 @@ describe('sourceNodes', () => {
       /https:\/\/deliver.kontent.ai\/.*\/types/,
       {
         fakeResponseJson: complexTypesFakeResponse,
+        throwError: false,
+      });
+    fakeComplexConfig.set(
+      /https:\/\/deliver.kontent.ai\/.*\/types/,
+      {
+        fakeResponseJson: fakeTaxonomyResponse,
         throwError: false,
       });
 

--- a/src/__tests__/gatsby-node.spec.js
+++ b/src/__tests__/gatsby-node.spec.js
@@ -10,7 +10,7 @@ const complexContentItemsSecondtLanguageFakeReponse =
   require('./complexContentItemsSecondLanguageFakeReponse.json');
 const complexTypesFakeResponse =
   require('./complexTypesFakeResponse.json');
-const fakeTaxonomyResponse = 
+const fakeTaxonomyResponse =
   require('./fakeTaxonomyResponse.json');
 
 describe('customTrackingHeader', () => {
@@ -62,7 +62,18 @@ describe('sourceNodes', () => {
         },
         throwError: false,
       });
-
+    fakeEmptyResponseConfig.set(
+      /https:\/\/deliver.kontent.ai\/.*\/taxonomies/,
+      {
+        fakeResponseJson: {
+          taxonomies: [],
+          pagination: {
+            continuation_token: null,
+            next_page: null,
+          },
+        },
+        throwError: false,
+      });
     const fakeEmptyTestService =
       new KontentTestHttpService(fakeEmptyResponseConfig);
 
@@ -164,7 +175,7 @@ describe('sourceNodes', () => {
         throwError: false,
       });
     fakeComplexConfig.set(
-      /https:\/\/deliver.kontent.ai\/.*\/types/,
+      /https:\/\/deliver.kontent.ai\/.*\/taxonomies/,
       {
         fakeResponseJson: fakeTaxonomyResponse,
         throwError: false,

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -6,6 +6,7 @@ const { DeliveryClient } = require(`@kentico/kontent-delivery`);
 const validation = require(`./validation`);
 const itemNodes = require('./itemNodes');
 const typeNodes = require('./typeNodes');
+const taxonomiesNodes = require('./taxonomyNodes');
 
 const languageVariantsDecorator =
   require('./decorators/languageVariantsDecorator');
@@ -43,6 +44,11 @@ exports.sourceNodes =
       client,
       createNodeId,
       includeRawContent
+    );
+
+    const taxonomyNodes = await taxonomiesNodes.get(
+      client, 
+      createNodeId
     );
 
     const defaultCultureContentItemNodes = await itemNodes.
@@ -93,6 +99,10 @@ exports.sourceNodes =
       console.info(`Creating content item nodes for default language.`);
     }
     createNodes(defaultCultureContentItemNodes, createNode);
+    if (enableLogging) {
+      console.info(`Creating taxonomy nodes`);
+    }
+    createNodes(taxonomyNodes, createNode);
 
     if (enableLogging) {
       console.info(`Creating content item nodes for non-default languages.`);
@@ -105,10 +115,12 @@ exports.sourceNodes =
 
     const typeNodesCount = contentTypeNodes.length;
     const itemsCount = contentTypeNodes.length + nonDefaultLanguagesCount;
+    const taxonomiesCount = taxonomyNodes.length;
     if (enableLogging) {
       console.info(`Kentico Kontent nodes generation finished.`);
       console.info(`${typeNodesCount} Kontent types item imported.`);
       console.info(`${itemsCount} Kontent items imported.`);
+      console.info(`${taxonomiesCount} Kontent taxonomies imported.`);
     }
     return;
   };

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -47,7 +47,7 @@ exports.sourceNodes =
     );
 
     const taxonomyNodes = await taxonomiesNodes.get(
-      client, 
+      client,
       createNodeId
     );
 

--- a/src/taxonomyNodes.js
+++ b/src/taxonomyNodes.js
@@ -1,0 +1,58 @@
+const { parse, stringify } = require('flatted/cjs');
+const _ = require('lodash');
+const changeCase = require('change-case');
+
+const normalize = require('./normalize');
+const validation = require('./validation');
+
+/**
+ * Creates an array of content type nodes ready to be imported to Gatsby model.
+ * @param {Object} client Delivery client
+ * @param {Function} createNodeId Gatsby method for generating ID
+ */
+const get = async (client, createNodeId) => {
+    const taxonomiesResponse = await client
+        .taxonomies()
+        .toPromise();
+    const taxonomiesFlatted = parse(stringify(taxonomiesResponse.taxonomies));
+    const taxonomyNodes = taxonomiesFlatted.map((taxonomy) => {
+        try {
+            return createTaxonomyNode(
+                createNodeId,
+                taxonomy);
+        } catch (error) {
+            console.error(error);
+        }
+    });
+    return taxonomyNodes;
+};
+
+/**
+ * Creates a Gatsby object out of a Kentico Cloud taxonomy object.
+ * @param {function} createNodeId - Gatsby function to create a node ID.
+ * @param {object} taxonomy - Kentico Cloud taxonomy object.
+ * @return {object} Gatsby content type node.
+ * @throws {Error}
+ */
+const createTaxonomyNode = (
+    createNodeId,
+    taxonomy) => {
+    if (!_.isFunction(createNodeId)) {
+        throw new Error(`createNodeId is not a function.`);
+    }
+
+    validation.checkTypesObjectStructure([taxonomy]);
+    const codenameParamCase = changeCase.paramCase(taxonomy.system.codename);
+    const nodeId = createNodeId(`kentico-cloud-taxonomy-${codenameParamCase}`);
+
+    return normalize.createKcArtifactNode(
+        nodeId,
+        taxonomy,
+        `taxonomy`,
+        taxonomy.system.codename
+    );
+};
+
+module.exports = {
+    get,
+};

--- a/src/validation.js
+++ b/src/validation.js
@@ -44,7 +44,7 @@ const checkItemsObjectStructure = (contentItemNodes) => {
   }
 };
 
-const checkTaxonomyObjectStructure = taxonomyNodes => {
+const checkTaxonomyObjectStructure = (taxonomyNodes) => {
   if (!hasBasicValidStructure(taxonomyNodes)) {
     throw new Error(`taxonomyNodes is not an array of valid objects.`);
   }
@@ -57,7 +57,7 @@ const hasBasicValidStructure = (contentNodes) => {
       && _.has(item, 'system.name')
       && _.has(item, 'system.codename')
       && (_.has(item, 'elements')) || _.has(item, 'terms'))
-  );
+    );
 };
 
 module.exports = {

--- a/src/validation.js
+++ b/src/validation.js
@@ -44,19 +44,26 @@ const checkItemsObjectStructure = (contentItemNodes) => {
   }
 };
 
+const checkTaxonomyObjectStructure = taxonomyNodes => {
+  if (!hasBasicValidStructure(taxonomyNodes)) {
+    throw new Error(`taxonomyNodes is not an array of valid objects.`);
+  }
+};
+
 const hasBasicValidStructure = (contentNodes) => {
   return _.isArray(contentNodes)
     && _.every(contentNodes, ((item) =>
       _.has(item, 'system.id')
       && _.has(item, 'system.name')
       && _.has(item, 'system.codename')
-      && _.has(item, 'elements')));
+      && (_.has(item, 'elements')) || _.has(item, 'terms'))
+  );
 };
 
 module.exports = {
   validateLanguageCodenames,
   checkTypesObjectStructure,
   checkItemsObjectStructure,
+  checkTaxonomyObjectStructure,
 };
 ;
-

--- a/taxonomyNodes.js
+++ b/taxonomyNodes.js
@@ -1,0 +1,56 @@
+"use strict";
+
+const {
+  parse,
+  stringify
+} = require('flatted/cjs');
+
+const _ = require('lodash');
+
+const changeCase = require('change-case');
+
+const normalize = require('./normalize');
+
+const validation = require('./validation');
+/**
+ * Creates an array of content type nodes ready to be imported to Gatsby model.
+ * @param {Object} client Delivery client
+ * @param {Function} createNodeId Gatsby method for generating ID
+ */
+
+
+const get = async (client, createNodeId) => {
+  const taxonomiesResponse = await client.taxonomies().toPromise();
+  const taxonomiesFlatted = parse(stringify(taxonomiesResponse.taxonomies));
+  const taxonomyNodes = taxonomiesFlatted.map(taxonomy => {
+    try {
+      return createTaxonomyNode(createNodeId, taxonomy);
+    } catch (error) {
+      console.error(error);
+    }
+  });
+  return taxonomyNodes;
+};
+/**
+ * Creates a Gatsby object out of a Kentico Cloud taxonomy object.
+ * @param {function} createNodeId - Gatsby function to create a node ID.
+ * @param {object} taxonomy - Kentico Cloud taxonomy object.
+ * @return {object} Gatsby content type node.
+ * @throws {Error}
+ */
+
+
+const createTaxonomyNode = (createNodeId, taxonomy) => {
+  if (!_.isFunction(createNodeId)) {
+    throw new Error(`createNodeId is not a function.`);
+  }
+
+  validation.checkTypesObjectStructure([taxonomy]);
+  const codenameParamCase = changeCase.paramCase(taxonomy.system.codename);
+  const nodeId = createNodeId(`kentico-cloud-taxonomy-${codenameParamCase}`);
+  return normalize.createKcArtifactNode(nodeId, taxonomy, `taxonomy`, taxonomy.system.codename);
+};
+
+module.exports = {
+  get
+};

--- a/taxonomyNodes.js
+++ b/taxonomyNodes.js
@@ -1,8 +1,8 @@
-"use strict";
+'use strict';
 
 const {
   parse,
-  stringify
+  stringify,
 } = require('flatted/cjs');
 
 const _ = require('lodash');
@@ -22,7 +22,7 @@ const validation = require('./validation');
 const get = async (client, createNodeId) => {
   const taxonomiesResponse = await client.taxonomies().toPromise();
   const taxonomiesFlatted = parse(stringify(taxonomiesResponse.taxonomies));
-  const taxonomyNodes = taxonomiesFlatted.map(taxonomy => {
+  const taxonomyNodes = taxonomiesFlatted.map((taxonomy) => {
     try {
       return createTaxonomyNode(createNodeId, taxonomy);
     } catch (error) {
@@ -52,5 +52,5 @@ const createTaxonomyNode = (createNodeId, taxonomy) => {
 };
 
 module.exports = {
-  get
+  get,
 };


### PR DESCRIPTION
### Motivation
Fixes #1 

Allows querying of terms in taxonomy groups.

Query: 

```gql
query MyQuery {
  allKontentTaxonomyCategories {
    nodes {
      terms {
        name
        codename
      }
      system {
        name
        codename
      }
    }
  }
}
```

Returns: 

```gql
{
  "data": {
    "allKontentTaxonomyCategories": {
      "nodes": [
        {
          "terms": [
            {
              "name": "Education",
              "codename": "education"
            },
            {
              "name": "Articles",
              "codename": "articles"
            }
          ],
          "system": {
            "name": "Categories",
            "codename": "categories"
          }
        }
      ]
    }
  }
}
```

Added node validation and tests.  All gatsby-node tests pass.  
Also updated README to show how to query all taxonomy groups and terms.

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [x] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Module installed properly and created requested nodes in GraphiQL.  Jest tests pass on gatsby-node.