### PR TITLE
Fix Kontent item relations

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,8 +173,6 @@ Should a *Linked items* element in KC contain items of only *one* type, you'll b
 
 The `related_project_refereces.linked_items` will give you the full-fledged Gatsby GraphQL nodes with all additional properties and links.
 
-> :bulb: Notice the encapsulation into the `... on Node` [GraphQL inline fragment](https://graphql.org/learn/queries/#inline-fragments). This prevent failing creating GraphQL model when this field does not contain i.e. Blog post (`KontentItemBlogpostReference`) linked item.
-
 ```gql
 {
   allKontentItemProjectReference {
@@ -185,20 +183,17 @@ The `related_project_refereces.linked_items` will give you the full-fledged Gats
           type
           itemCodenames
           linked_items {
-            ... on Node {
-              __typename
-              ... on KontentItemBlogpostReference {
-                elements {
-                  title {
-                    value
-                  }
+            ... on KontentItemBlogpostReference {
+              elements {
+                title {
+                  value
                 }
               }
-              ... on KontentItemProjectReference {
-                elements {
-                  project_name {
-                    value
-                  }
+            }
+            ... on KontentItemProjectReference {
+              elements {
+                project_name {
+                  value
                 }
               }
             }
@@ -274,13 +269,10 @@ As with the previous example, all rich text element containing [inline content i
         summary {
           value
           linked_items {
-            ... on Node {
-            __typename
-            ... on KontentItemBlogpostReference {
-              elements {
-                title {
-                  value
-                }
+          ... on KontentItemBlogpostReference {
+            elements {
+              title {
+                value
               }
             }
           }

--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -194,9 +194,45 @@ Rich text elements internal structure was extended. The main difference is that 
 }
 ```
 
-### Schema definition API & All items query
+### Schema definition API
 
 Thanks to [#80](https://github.com/Kentico/gatsby-source-kontent/pull/80) it is possible remove the [fully filled dummy content items](https://github.com/Kentico/gatsby-source-kontent/issues/59#issuecomment-496412677) from Kentico Kontent to provide Gatsby inference engine information about content structure.
+
+For linked items in linked items element nor for rich text element encapsulation into the `... on Node` [GraphQL inline fragment](https://graphql.org/learn/queries/#inline-fragments) is not required any more ([#82](https://github.com/Kentico/gatsby-source-kontent/pull/82)).
+
+```gql
+{
+  allKontentItemProjectReference {
+    nodes {
+      elements {
+        related_project_references {
+          linked_items {
+            ... on Node { // NOT REQUIRED
+              __typename
+              ... on KontentItemBlogpostReference {
+                elements {
+                  title {
+                    value
+                  }
+                }
+              }
+              ... on KontentItemProjectReference {
+                elements {
+                  project_name {
+                    value
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+#### All Item query
 
 As a part of that adjustment there are two queries (`allKontentItem` and `kontentItem`) allows to load content items from unified endpoint regardless of type
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kentico/gatsby-source-kontent",
-  "version": "4.0.0-beta2",
+  "version": "4.0.0-beta4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kentico/gatsby-source-kontent",
-  "version": "4.0.0-beta3",
+  "version": "4.0.0-beta4",
   "description": "Gatsby source plugin for Kentico Kontent",
   "main": "./gatsby-node.js",
   "scripts": {
@@ -45,7 +45,7 @@
     "rxjs": "^6.5.3"
   },
   "peerDependencies": {
-    "gatsby": ">=2.1.18"
+    "gatsby": ">=2.2.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",

--- a/src/__tests__/types-schema-resolution/__snapshots__/types-schema-resolution.spec.js.snap
+++ b/src/__tests__/types-schema-resolution/__snapshots__/types-schema-resolution.spec.js.snap
@@ -66,7 +66,7 @@ Array [
       name: String!
       type: String!
       itemCodenames: [String]
-      value: [KontentItem] @link(by: \\"system.codename\\")
+      linked_items: [KontentItem] @link(by: \\"id\\", from: \\"linked_items___NODE\\")
     }
     type KontentMultipleChoiceElement implements KontentElement @infer {
       name: String!
@@ -84,7 +84,7 @@ Array [
       value: String
       images: [KontentRichTextImage]
       links: [KontentRichTextLink]
-      linked_items: [KontentItem] @link(by: \\"system.codename\\")
+      linked_items: [KontentItem] @link(by: \\"id\\", from: \\"linked_items___NODE\\")
       linkedItemCodenames: [String]
       resolvedData: KontentElementRichTextResolvedData
     }

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,6 @@
 const customTrackingHeader = {
   header: 'X-KC-SOURCE',
-  value: '@kentico/gatsby-source-kontent;4.0.0-beta3',
+  value: '@kentico/gatsby-source-kontent;4.0.0-beta4',
 };
 
 module.exports = {

--- a/src/typeNodesSchema.js
+++ b/src/typeNodesSchema.js
@@ -8,18 +8,17 @@ const changeCase = require('change-case');
  * @param {function} createTypes - Gatsby function to create a type
  */
 const createTypeNodesSchema = async (client, schema, createTypes) => {
-  createTypes(getKontentBaseTypeDefintions());
+  const baseSchemaTypes = getKontentBaseTypeDefinitions();
+  createTypes(baseSchemaTypes);
 
   const kontentTypesResponse = await client.types().toPromise();
 
-  createTypes(
-    kontentTypesResponse.types.reduce(
-      (typeDefinitions, type) => {
-        const fieldTypeDefinition = createFieldDefinitionsForType(schema, type);
-        return typeDefinitions.concat(fieldTypeDefinition);
-      }, [],
-    ),
-  );
+  const schemaTypes =
+    kontentTypesResponse.types.reduce((typeDefinitions, type) => {
+      const fieldTypeDefinition = createFieldDefinitionsForType(schema, type);
+      return typeDefinitions.concat(fieldTypeDefinition);
+    }, []);
+  createTypes(schemaTypes);
 };
 
 const createFieldDefinitionsForType = (schema, type) => {
@@ -59,7 +58,7 @@ const getElementValueType = (elementType) => {
   return `Kontent${changeCase.pascalCase(elementType)}Element`;
 };
 
-const getKontentBaseTypeDefintions = () => {
+const getKontentBaseTypeDefinitions = () => {
   const typeDefs = `
     interface KontentItem @nodeInterface {
       id: ID!
@@ -123,7 +122,7 @@ const getKontentBaseTypeDefintions = () => {
       name: String!
       type: String!
       itemCodenames: [String]
-      value: [KontentItem] @link(by: "system.codename")
+      linked_items: [KontentItem] @link(by: "id", from: "linked_items___NODE")
     }
     type KontentMultipleChoiceElement implements KontentElement @infer {
       name: String!
@@ -141,7 +140,7 @@ const getKontentBaseTypeDefintions = () => {
       value: String
       images: [KontentRichTextImage]
       links: [KontentRichTextLink]
-      linked_items: [KontentItem] @link(by: "system.codename")
+      linked_items: [KontentItem] @link(by: "id", from: "linked_items___NODE")
       linkedItemCodenames: [String]
       resolvedData: KontentElementRichTextResolvedData
     }


### PR DESCRIPTION
### Motivation

Related: #80
Fixes: #59

When querying the `linked_items` property of the linked items element returned `null` as well as for rich text linked element even the data were linked in Kentico Kontent.

Fix linked items for linked items in linked items element as well as rich text linked elements.

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Test that data are propagated from Kentico kontent to the `linked_items` property for linked elements as well as a rich text element.