### PR TITLE
Move schema customization code to proper livecycle method

### DIFF
--- a/src/__tests__/types-schema-resolution/types-schema-resolution.spec.js
+++ b/src/__tests__/types-schema-resolution/types-schema-resolution.spec.js
@@ -2,7 +2,7 @@
 const { KontentTestHttpService }
   = require('@kentico/kontent-test-http-service-js');
 
-const { sourceNodes } = require('../../gatsby-node');
+const { createSchemaCustomization } = require('../../gatsby-node');
 
 const fakeTypesResponse =
   require('./fakeTypesResponse.json');
@@ -35,10 +35,6 @@ describe(
         throwError: false,
       });
 
-    const dummyCreateNodeID = jest.fn();
-    dummyCreateNodeID.mockImplementation((input) => `dummy-${input}`);
-
-    const createNodeMock = jest.fn();
     const createTypesMock = jest.fn();
 
     const mockedSchema = { buildObjectType: jest.fn((input) => (
@@ -46,12 +42,10 @@ describe(
         Original input: ${input}`,
       }))}; ;
 
-    const actions = {
+    const api = {
       actions: {
-        createNode: createNodeMock,
         createTypes: createTypesMock,
       },
-      createNodeId: dummyCreateNodeID,
       schema: mockedSchema,
     };
     const deliveryClientConfig = {
@@ -68,7 +62,7 @@ describe(
     };
 
     it('passes with no error', async () => {
-      await sourceNodes(actions, pluginConfiguration);
+      await createSchemaCustomization(api, pluginConfiguration);
 
       const createTypeCalls = createTypesMock.mock.calls;
       expect(createTypeCalls).toHaveLength(2);

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -19,9 +19,41 @@ const richTextElementDecorator =
   require('./decorators/richTextElementDecorator');
 const { customTrackingHeader, addHeader } = require('./config');
 
+exports.createSchemaCustomization = async (api, pluginConfig) => {
+  const {
+    actions: {
+      createTypes,
+    },
+    schema,
+  } = api;
+
+  const {
+    deliveryClientConfig,
+    enableLogging = false,
+  } = pluginConfig;
+
+  const kontentClientConfig =
+    addHeader(deliveryClientConfig, customTrackingHeader);
+
+  const client = new DeliveryClient(kontentClientConfig);
+
+
+  if (enableLogging) {
+    console.info(
+      `Creating type nodes schema.`
+    );
+  }
+
+  await typeNodesSchema.createTypeNodesSchema(
+    client,
+    schema,
+    createTypes,
+  );
+};
+
 
 exports.sourceNodes =
-  async ({ actions: { createNode, createTypes }, createNodeId, schema },
+  async ({ actions: { createNode }, createNodeId },
     { deliveryClientConfig,
       languageCodenames,
       enableLogging = false,
@@ -46,17 +78,6 @@ exports.sourceNodes =
       client,
       createNodeId,
       includeRawContent,
-    );
-
-    if (enableLogging) {
-      console.info(
-        `Creating type nodes schema.`,
-      );
-    }
-    await typeNodesSchema.createTypeNodesSchema(
-      client,
-      schema,
-      createTypes,
     );
 
     const defaultCultureContentItemNodes = await itemNodes.

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -53,13 +53,21 @@ exports.createSchemaCustomization = async (api, pluginConfig) => {
 
 
 exports.sourceNodes =
-  async ({ actions: { createNode }, createNodeId },
-    { deliveryClientConfig,
+  async (api, pluginConfig) => {
+    const {
+      actions: {
+        createNode,
+      },
+      createNodeId,
+    } = api;
+
+    const {
+      deliveryClientConfig,
       languageCodenames,
       enableLogging = false,
       includeRawContent = false,
-    },
-  ) => {
+    } = pluginConfig;
+
     if (enableLogging) {
       console.info(`Generating Kentico Kontent nodes for projectId:\
  ${_.get(deliveryClientConfig, 'projectId')}`);


### PR DESCRIPTION
### Motivation

To ensure the schema customization is preserved on Gatsby's preview.
* https://www.gatsbyjs.org/docs/schema-customization/#fixing-field-types
