### PR TITLE
Fix conflicting codenames for kontent items.

### DIFF
--- a/src/__tests__/custom-element-resolver/__snapshots__/customElementResolver.spec.js.snap
+++ b/src/__tests__/custom-element-resolver/__snapshots__/customElementResolver.spec.js.snap
@@ -58,7 +58,7 @@ Array [
     Object {
       "children": Array [],
       "contentItems___NODE": Array [
-        "dummy-kentico-kontent-item-content-item-1-default",
+        "dummy-kentico-kontent-item-content_item_1-default",
       ],
       "elements": Array [
         Object {
@@ -96,7 +96,7 @@ Array [
           "videoId": "_Yhyp-_hX2s",
         },
       },
-      "id": "dummy-kentico-kontent-item-content-item-1-default",
+      "id": "dummy-kentico-kontent-item-content_item_1-default",
       "internal": Object {
         "contentDigest": "7be3f945c82e0dc4ac4aa36f4be493b9",
         "type": "KontentItemContentType",

--- a/src/__tests__/item-conflicting-codenames/__snapshots__/item-conflicting-codenames.spec.js.snap
+++ b/src/__tests__/item-conflicting-codenames/__snapshots__/item-conflicting-codenames.spec.js.snap
@@ -1,0 +1,340 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Codenames with conflicting underscores passes with no error 1`] = `
+Array [
+  Array [
+    Object {
+      "children": Array [],
+      "id": "dummy-kentico-kontent-taxonomy-personas",
+      "internal": Object {
+        "contentDigest": "91ece672836106bfc0f186606f20a01d",
+        "type": "KontentTaxonomyPersonas",
+      },
+      "parent": null,
+      "system": Object {
+        "codename": "personas",
+        "id": "f30c7f72-e9ab-8832-2a57-62944a038809",
+        "lastModified": "2016-10-20T13:24:00.3200000Z",
+        "name": "Personas",
+      },
+      "terms": Array [
+        Object {
+          "codename": "coffee_expert",
+          "name": "Coffee expert",
+          "terms": Array [
+            Object {
+              "codename": "barista",
+              "name": "Barista",
+              "terms": Array [],
+            },
+            Object {
+              "codename": "cafe_owner",
+              "name": "Cafe owner",
+              "terms": Array [],
+            },
+          ],
+        },
+        Object {
+          "codename": "coffee_enthusiast",
+          "name": "Coffee enthusiast",
+          "terms": Array [
+            Object {
+              "codename": "coffee_lover",
+              "name": "Coffee lover",
+              "terms": Array [],
+            },
+            Object {
+              "codename": "coffee_blogger",
+              "name": "Coffee blogger",
+              "terms": Array [],
+            },
+          ],
+        },
+      ],
+      "usedByContentItems___NODE": Array [],
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentItems___NODE": Array [
+        "dummy-kentico-kontent-item-__child-default",
+        "dummy-kentico-kontent-item-_child-default",
+        "dummy-kentico-kontent-item-chi__ld-default",
+        "dummy-kentico-kontent-item-chi_ld-default",
+        "dummy-kentico-kontent-item-child-default",
+      ],
+      "elements": Array [
+        Object {
+          "codename": "title",
+          "name": "Title",
+          "options": Array [],
+          "type": "text",
+        },
+      ],
+      "id": "dummy-kentico-kontent-type-child",
+      "internal": Object {
+        "contentDigest": "81f25311660f4dd7fb0117f729b022c8",
+        "type": "KontentTypeChild",
+      },
+      "parent": null,
+      "system": Object {
+        "codename": "child",
+        "id": "7593cb08-f848-42dd-b6df-b8e619025a3c",
+        "lastModified": "2020-03-03T09:15:59.4486118Z",
+        "name": "Child",
+      },
+      "usedByContentItems___NODE": Array [],
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentItems___NODE": Array [
+        "dummy-kentico-kontent-item-conflicted_codenames-default",
+      ],
+      "elements": Array [
+        Object {
+          "codename": "title",
+          "name": "Title",
+          "options": Array [],
+          "type": "text",
+        },
+        Object {
+          "codename": "children",
+          "name": "Children",
+          "options": Array [],
+          "type": "modular_content",
+        },
+      ],
+      "id": "dummy-kentico-kontent-type-parent",
+      "internal": Object {
+        "contentDigest": "6a2d9285c3b1c3de788764dd872583df",
+        "type": "KontentTypeParent",
+      },
+      "parent": null,
+      "system": Object {
+        "codename": "parent",
+        "id": "d1cd2f83-60e8-4416-b2e7-d73b1361d3e7",
+        "lastModified": "2020-03-03T09:15:37.2966743Z",
+        "name": "Parent",
+      },
+      "usedByContentItems___NODE": Array [],
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentType___NODE": "dummy-kentico-kontent-type-child",
+      "elements": Object {
+        "title": Object {
+          "name": "Title",
+          "type": "text",
+          "value": "__child",
+        },
+      },
+      "id": "dummy-kentico-kontent-item-__child-default",
+      "internal": Object {
+        "contentDigest": "3959787e5d5552d79209516b5fb2e88d",
+        "type": "KontentItemChild",
+      },
+      "otherLanguages___NODE": Array [],
+      "parent": null,
+      "preferred_language": "default",
+      "system": Object {
+        "codename": "__child",
+        "id": "60fbe92a-a491-43b5-841f-e8c838d7b31f",
+        "language": "default",
+        "lastModified": "2020-03-03T09:17:43.317Z",
+        "name": "__child",
+        "sitemapLocations": Array [],
+        "type": "child",
+      },
+      "usedByContentItems___NODE": Array [
+        "dummy-kentico-kontent-item-conflicted_codenames-default",
+      ],
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentType___NODE": "dummy-kentico-kontent-type-child",
+      "elements": Object {
+        "title": Object {
+          "name": "Title",
+          "type": "text",
+          "value": "_child",
+        },
+      },
+      "id": "dummy-kentico-kontent-item-_child-default",
+      "internal": Object {
+        "contentDigest": "b3ec086bb7d24eb366112f7f75dbe742",
+        "type": "KontentItemChild",
+      },
+      "otherLanguages___NODE": Array [],
+      "parent": null,
+      "preferred_language": "default",
+      "system": Object {
+        "codename": "_child",
+        "id": "04e1d690-ee87-4791-931c-64ef5343c2cd",
+        "language": "default",
+        "lastModified": "2020-03-03T09:16:58.873Z",
+        "name": "_child",
+        "sitemapLocations": Array [],
+        "type": "child",
+      },
+      "usedByContentItems___NODE": Array [
+        "dummy-kentico-kontent-item-conflicted_codenames-default",
+      ],
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentType___NODE": "dummy-kentico-kontent-type-child",
+      "elements": Object {
+        "title": Object {
+          "name": "Title",
+          "type": "text",
+          "value": "chi__ld",
+        },
+      },
+      "id": "dummy-kentico-kontent-item-chi__ld-default",
+      "internal": Object {
+        "contentDigest": "7a68795a05a97fb8f4717b2b5351df27",
+        "type": "KontentItemChild",
+      },
+      "otherLanguages___NODE": Array [],
+      "parent": null,
+      "preferred_language": "default",
+      "system": Object {
+        "codename": "chi__ld",
+        "id": "c7a0bf25-0acf-4a35-8a82-48360afc64bb",
+        "language": "default",
+        "lastModified": "2020-03-03T09:18:52.451Z",
+        "name": "chi__ld",
+        "sitemapLocations": Array [],
+        "type": "child",
+      },
+      "usedByContentItems___NODE": Array [
+        "dummy-kentico-kontent-item-conflicted_codenames-default",
+      ],
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentType___NODE": "dummy-kentico-kontent-type-child",
+      "elements": Object {
+        "title": Object {
+          "name": "Title",
+          "type": "text",
+          "value": "chi_ld",
+        },
+      },
+      "id": "dummy-kentico-kontent-item-chi_ld-default",
+      "internal": Object {
+        "contentDigest": "cbac187d9e65b0785c3ba67b24636f16",
+        "type": "KontentItemChild",
+      },
+      "otherLanguages___NODE": Array [],
+      "parent": null,
+      "preferred_language": "default",
+      "system": Object {
+        "codename": "chi_ld",
+        "id": "71984f0b-fbb1-4f25-b329-095e9aaa6fa0",
+        "language": "default",
+        "lastModified": "2020-03-03T09:18:16.183Z",
+        "name": "chi_ld",
+        "sitemapLocations": Array [],
+        "type": "child",
+      },
+      "usedByContentItems___NODE": Array [
+        "dummy-kentico-kontent-item-conflicted_codenames-default",
+      ],
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentType___NODE": "dummy-kentico-kontent-type-child",
+      "elements": Object {
+        "title": Object {
+          "name": "Title",
+          "type": "text",
+          "value": "child",
+        },
+      },
+      "id": "dummy-kentico-kontent-item-child-default",
+      "internal": Object {
+        "contentDigest": "85fd0a581609e763f24158c40cece0f1",
+        "type": "KontentItemChild",
+      },
+      "otherLanguages___NODE": Array [],
+      "parent": null,
+      "preferred_language": "default",
+      "system": Object {
+        "codename": "child",
+        "id": "2d995afc-8e73-4d10-bd19-fc2857c19e92",
+        "language": "default",
+        "lastModified": "2020-03-03T09:17:17.778Z",
+        "name": "child",
+        "sitemapLocations": Array [],
+        "type": "child",
+      },
+      "usedByContentItems___NODE": Array [
+        "dummy-kentico-kontent-item-conflicted_codenames-default",
+      ],
+    },
+  ],
+  Array [
+    Object {
+      "children": Array [],
+      "contentType___NODE": "dummy-kentico-kontent-type-parent",
+      "elements": Object {
+        "children": Object {
+          "itemCodenames": Array [
+            "child",
+            "_child",
+            "__child",
+            "chi_ld",
+            "chi__ld",
+          ],
+          "linked_items___NODE": Array [
+            "dummy-kentico-kontent-item-child-default",
+            "dummy-kentico-kontent-item-_child-default",
+            "dummy-kentico-kontent-item-__child-default",
+            "dummy-kentico-kontent-item-chi_ld-default",
+            "dummy-kentico-kontent-item-chi__ld-default",
+          ],
+          "name": "Children",
+          "type": "modular_content",
+        },
+        "title": Object {
+          "name": "Title",
+          "type": "text",
+          "value": "Conflicted Codenames",
+        },
+      },
+      "id": "dummy-kentico-kontent-item-conflicted_codenames-default",
+      "internal": Object {
+        "contentDigest": "c1ab8d9a8538814b5777b9d75275f9b2",
+        "type": "KontentItemParent",
+      },
+      "otherLanguages___NODE": Array [],
+      "parent": null,
+      "preferred_language": "default",
+      "system": Object {
+        "codename": "conflicted_codenames",
+        "id": "c66d1a0b-a9b6-4b45-8e6f-5f30550806f0",
+        "language": "default",
+        "lastModified": "2020-03-03T09:18:44.142Z",
+        "name": "Conflicted Codenames",
+        "sitemapLocations": Array [],
+        "type": "parent",
+      },
+      "usedByContentItems___NODE": Array [],
+    },
+  ],
+]
+`;

--- a/src/__tests__/item-conflicting-codenames/conflictingCodenamesItemsResponse.json
+++ b/src/__tests__/item-conflicting-codenames/conflictingCodenamesItemsResponse.json
@@ -1,0 +1,221 @@
+{
+  "items": [
+    {
+      "system": {
+        "id": "60fbe92a-a491-43b5-841f-e8c838d7b31f",
+        "name": "__child",
+        "codename": "__child",
+        "language": "default",
+        "type": "child",
+        "sitemap_locations": [],
+        "last_modified": "2020-03-03T09:17:43.3179479Z"
+      },
+      "elements": {
+        "title": {
+          "type": "text",
+          "name": "Title",
+          "value": "__child"
+        }
+      }
+    },
+    {
+      "system": {
+        "id": "04e1d690-ee87-4791-931c-64ef5343c2cd",
+        "name": "_child",
+        "codename": "_child",
+        "language": "default",
+        "type": "child",
+        "sitemap_locations": [],
+        "last_modified": "2020-03-03T09:16:58.8739219Z"
+      },
+      "elements": {
+        "title": {
+          "type": "text",
+          "name": "Title",
+          "value": "_child"
+        }
+      }
+    },
+    {
+      "system": {
+        "id": "c7a0bf25-0acf-4a35-8a82-48360afc64bb",
+        "name": "chi__ld",
+        "codename": "chi__ld",
+        "language": "default",
+        "type": "child",
+        "sitemap_locations": [],
+        "last_modified": "2020-03-03T09:18:52.451175Z"
+      },
+      "elements": {
+        "title": {
+          "type": "text",
+          "name": "Title",
+          "value": "chi__ld"
+        }
+      }
+    },
+    {
+      "system": {
+        "id": "71984f0b-fbb1-4f25-b329-095e9aaa6fa0",
+        "name": "chi_ld",
+        "codename": "chi_ld",
+        "language": "default",
+        "type": "child",
+        "sitemap_locations": [],
+        "last_modified": "2020-03-03T09:18:16.1835478Z"
+      },
+      "elements": {
+        "title": {
+          "type": "text",
+          "name": "Title",
+          "value": "chi_ld"
+        }
+      }
+    },
+    {
+      "system": {
+        "id": "2d995afc-8e73-4d10-bd19-fc2857c19e92",
+        "name": "child",
+        "codename": "child",
+        "language": "default",
+        "type": "child",
+        "sitemap_locations": [],
+        "last_modified": "2020-03-03T09:17:17.7783968Z"
+      },
+      "elements": {
+        "title": {
+          "type": "text",
+          "name": "Title",
+          "value": "child"
+        }
+      }
+    },
+    {
+      "system": {
+        "id": "c66d1a0b-a9b6-4b45-8e6f-5f30550806f0",
+        "name": "Conflicted Codenames",
+        "codename": "conflicted_codenames",
+        "language": "default",
+        "type": "parent",
+        "sitemap_locations": [],
+        "last_modified": "2020-03-03T09:18:44.1424674Z"
+      },
+      "elements": {
+        "title": {
+          "type": "text",
+          "name": "Title",
+          "value": "Conflicted Codenames"
+        },
+        "children": {
+          "type": "modular_content",
+          "name": "Children",
+          "value": [
+            "child",
+            "_child",
+            "__child",
+            "chi_ld",
+            "chi__ld"
+          ]
+        }
+      }
+    }
+  ],
+  "modular_content": {
+    "__child": {
+      "system": {
+        "id": "60fbe92a-a491-43b5-841f-e8c838d7b31f",
+        "name": "__child",
+        "codename": "__child",
+        "language": "default",
+        "type": "child",
+        "sitemap_locations": [],
+        "last_modified": "2020-03-03T09:17:43.3179479Z"
+      },
+      "elements": {
+        "title": {
+          "type": "text",
+          "name": "Title",
+          "value": "__child"
+        }
+      }
+    },
+    "_child": {
+      "system": {
+        "id": "04e1d690-ee87-4791-931c-64ef5343c2cd",
+        "name": "_child",
+        "codename": "_child",
+        "language": "default",
+        "type": "child",
+        "sitemap_locations": [],
+        "last_modified": "2020-03-03T09:16:58.8739219Z"
+      },
+      "elements": {
+        "title": {
+          "type": "text",
+          "name": "Title",
+          "value": "_child"
+        }
+      }
+    },
+    "chi__ld": {
+      "system": {
+        "id": "c7a0bf25-0acf-4a35-8a82-48360afc64bb",
+        "name": "chi__ld",
+        "codename": "chi__ld",
+        "language": "default",
+        "type": "child",
+        "sitemap_locations": [],
+        "last_modified": "2020-03-03T09:18:52.451175Z"
+      },
+      "elements": {
+        "title": {
+          "type": "text",
+          "name": "Title",
+          "value": "chi__ld"
+        }
+      }
+    },
+    "chi_ld": {
+      "system": {
+        "id": "71984f0b-fbb1-4f25-b329-095e9aaa6fa0",
+        "name": "chi_ld",
+        "codename": "chi_ld",
+        "language": "default",
+        "type": "child",
+        "sitemap_locations": [],
+        "last_modified": "2020-03-03T09:18:16.1835478Z"
+      },
+      "elements": {
+        "title": {
+          "type": "text",
+          "name": "Title",
+          "value": "chi_ld"
+        }
+      }
+    },
+    "child": {
+      "system": {
+        "id": "2d995afc-8e73-4d10-bd19-fc2857c19e92",
+        "name": "child",
+        "codename": "child",
+        "language": "default",
+        "type": "child",
+        "sitemap_locations": [],
+        "last_modified": "2020-03-03T09:17:17.7783968Z"
+      },
+      "elements": {
+        "title": {
+          "type": "text",
+          "name": "Title",
+          "value": "child"
+        }
+      }
+    }
+  },
+  "pagination": {
+    "skip": 0,
+    "limit": 0,
+    "count": 6,
+    "next_page": ""
+  }
+}

--- a/src/__tests__/item-conflicting-codenames/fakeTypeResponse.json
+++ b/src/__tests__/item-conflicting-codenames/fakeTypeResponse.json
@@ -1,0 +1,42 @@
+{
+  "types": [
+    {
+      "system": {
+        "id": "7593cb08-f848-42dd-b6df-b8e619025a3c",
+        "name": "Child",
+        "codename": "child",
+        "last_modified": "2020-03-03T09:15:59.4486118Z"
+      },
+      "elements": {
+        "title": {
+          "type": "text",
+          "name": "Title"
+        }
+      }
+    },
+    {
+      "system": {
+        "id": "d1cd2f83-60e8-4416-b2e7-d73b1361d3e7",
+        "name": "Parent",
+        "codename": "parent",
+        "last_modified": "2020-03-03T09:15:37.2966743Z"
+      },
+      "elements": {
+        "title": {
+          "type": "text",
+          "name": "Title"
+        },
+        "children": {
+          "type": "modular_content",
+          "name": "Children"
+        }
+      }
+    }
+  ],
+  "pagination": {
+    "skip": 0,
+    "limit": 0,
+    "count": 2,
+    "next_page": ""
+  }
+}

--- a/src/__tests__/item-conflicting-codenames/item-conflicting-codenames.spec.js
+++ b/src/__tests__/item-conflicting-codenames/item-conflicting-codenames.spec.js
@@ -1,0 +1,74 @@
+
+const { KontentTestHttpService }
+= require('@kentico/kontent-test-http-service-js');
+
+const { sourceNodes } = require('../../gatsby-node');
+
+// Project ID 532c0844-5eb3-0033-7d1b-faeea1e7e407
+const conflictingCodenamesItemsResponse =
+require('./conflictingCodenamesItemsResponse.json');
+const fakeTypeResponse =
+require('./fakeTypeResponse.json');
+const fakeTaxonomiesResponse =
+require('../fakeTaxonomiesResponse.json');
+
+describe(`Codenames with conflicting underscores`, () => {
+  const fakeHttpServiceConfig = new Map();
+  fakeHttpServiceConfig.set(
+    /https:\/\/deliver.kontent.ai\/.*\/items/,
+    {
+      fakeResponseJson: conflictingCodenamesItemsResponse,
+      throwError: false,
+    });
+  fakeHttpServiceConfig.set(
+    /https:\/\/deliver.kontent.ai\/.*\/types/,
+    {
+      fakeResponseJson: fakeTypeResponse,
+      throwError: false,
+    });
+
+  fakeHttpServiceConfig.set(
+    /https:\/\/deliver.kontent.ai\/.*\/taxonomies/,
+    {
+      fakeResponseJson: fakeTaxonomiesResponse,
+      throwError: false,
+    });
+
+  const dummyCreateNodeID = jest.fn();
+  dummyCreateNodeID.mockImplementation((input) => `dummy-${input}`);
+
+  const createNodeMock = jest.fn();
+  const createTypesMock = jest.fn();
+  const mockedSchema = { buildObjectType: jest.fn((input) => ({
+    data: input,
+  }))}; ;
+
+  const actions = {
+    actions: {
+      createNode: createNodeMock,
+      createTypes: createTypesMock,
+    },
+    createNodeId: dummyCreateNodeID,
+    schema: mockedSchema,
+  };
+
+  const deliveryClientConfig = {
+    projectId: 'dummyProject',
+    typeResolvers: [],
+    httpService: new KontentTestHttpService(
+      fakeHttpServiceConfig,
+    ),
+  };
+
+  const pluginConfiguration = {
+    deliveryClientConfig,
+    languageCodenames: ['default'],
+  };
+
+  it('passes with no error', async () => {
+    await sourceNodes(actions, pluginConfiguration);
+
+    const calls = createNodeMock.mock.calls;
+    expect(calls).toMatchSnapshot();
+  });
+});

--- a/src/__tests__/linked-items/__snapshots__/circular-reference.spec.js.snap
+++ b/src/__tests__/linked-items/__snapshots__/circular-reference.spec.js.snap
@@ -58,8 +58,8 @@ Array [
     Object {
       "children": Array [],
       "contentItems___NODE": Array [
-        "dummy-kentico-kontent-item-main-project-default",
-        "dummy-kentico-kontent-item-sub-project-1-default",
+        "dummy-kentico-kontent-item-main_project-default",
+        "dummy-kentico-kontent-item-sub_project_1-default",
       ],
       "elements": Array [
         Object {
@@ -106,14 +106,14 @@ Array [
             "main_project",
           ],
           "linked_items___NODE": Array [
-            "dummy-kentico-kontent-item-sub-project-1-default",
-            "dummy-kentico-kontent-item-main-project-default",
+            "dummy-kentico-kontent-item-sub_project_1-default",
+            "dummy-kentico-kontent-item-main_project-default",
           ],
           "name": "Related projects",
           "type": "modular_content",
         },
       },
-      "id": "dummy-kentico-kontent-item-main-project-default",
+      "id": "dummy-kentico-kontent-item-main_project-default",
       "internal": Object {
         "contentDigest": "b781959410c08f6071bf0deb02d1f048",
         "type": "KontentItemProject",
@@ -131,8 +131,8 @@ Array [
         "type": "project",
       },
       "usedByContentItems___NODE": Array [
-        "dummy-kentico-kontent-item-main-project-default",
-        "dummy-kentico-kontent-item-sub-project-1-default",
+        "dummy-kentico-kontent-item-main_project-default",
+        "dummy-kentico-kontent-item-sub_project_1-default",
       ],
     },
   ],
@@ -151,13 +151,13 @@ Array [
             "main_project",
           ],
           "linked_items___NODE": Array [
-            "dummy-kentico-kontent-item-main-project-default",
+            "dummy-kentico-kontent-item-main_project-default",
           ],
           "name": "Related projects",
           "type": "modular_content",
         },
       },
-      "id": "dummy-kentico-kontent-item-sub-project-1-default",
+      "id": "dummy-kentico-kontent-item-sub_project_1-default",
       "internal": Object {
         "contentDigest": "eea050f00dd7e1572aaa9e122104cbe8",
         "type": "KontentItemProject",
@@ -175,7 +175,7 @@ Array [
         "type": "project",
       },
       "usedByContentItems___NODE": Array [
-        "dummy-kentico-kontent-item-main-project-default",
+        "dummy-kentico-kontent-item-main_project-default",
       ],
     },
   ],

--- a/src/__tests__/linked-items/__snapshots__/simple-resolution.spec.js.snap
+++ b/src/__tests__/linked-items/__snapshots__/simple-resolution.spec.js.snap
@@ -58,9 +58,9 @@ Array [
     Object {
       "children": Array [],
       "contentItems___NODE": Array [
-        "dummy-kentico-kontent-item-main-project-default",
-        "dummy-kentico-kontent-item-sub-project-1-default",
-        "dummy-kentico-kontent-item-sub-project-2-default",
+        "dummy-kentico-kontent-item-main_project-default",
+        "dummy-kentico-kontent-item-sub_project_1-default",
+        "dummy-kentico-kontent-item-sub_project_2-default",
       ],
       "elements": Array [
         Object {
@@ -107,14 +107,14 @@ Array [
             "sub_project_2",
           ],
           "linked_items___NODE": Array [
-            "dummy-kentico-kontent-item-sub-project-1-default",
-            "dummy-kentico-kontent-item-sub-project-2-default",
+            "dummy-kentico-kontent-item-sub_project_1-default",
+            "dummy-kentico-kontent-item-sub_project_2-default",
           ],
           "name": "Related projects",
           "type": "modular_content",
         },
       },
-      "id": "dummy-kentico-kontent-item-main-project-default",
+      "id": "dummy-kentico-kontent-item-main_project-default",
       "internal": Object {
         "contentDigest": "687b23c106b8808afe59b94337833cf5",
         "type": "KontentItemProject",
@@ -151,7 +151,7 @@ Array [
           "type": "modular_content",
         },
       },
-      "id": "dummy-kentico-kontent-item-sub-project-1-default",
+      "id": "dummy-kentico-kontent-item-sub_project_1-default",
       "internal": Object {
         "contentDigest": "c4c8b4661ac9eb32063d20f24c2c492d",
         "type": "KontentItemProject",
@@ -169,7 +169,7 @@ Array [
         "type": "project",
       },
       "usedByContentItems___NODE": Array [
-        "dummy-kentico-kontent-item-main-project-default",
+        "dummy-kentico-kontent-item-main_project-default",
       ],
     },
   ],
@@ -190,7 +190,7 @@ Array [
           "type": "modular_content",
         },
       },
-      "id": "dummy-kentico-kontent-item-sub-project-2-default",
+      "id": "dummy-kentico-kontent-item-sub_project_2-default",
       "internal": Object {
         "contentDigest": "514309c2d98ca52e7160d8e189754db0",
         "type": "KontentItemProject",
@@ -208,7 +208,7 @@ Array [
         "type": "project",
       },
       "usedByContentItems___NODE": Array [
-        "dummy-kentico-kontent-item-main-project-default",
+        "dummy-kentico-kontent-item-main_project-default",
       ],
     },
   ],

--- a/src/__tests__/richtext-resolution/__snapshots__/circular-reference.spec.js.snap
+++ b/src/__tests__/richtext-resolution/__snapshots__/circular-reference.spec.js.snap
@@ -58,7 +58,7 @@ Array [
     Object {
       "children": Array [],
       "contentItems___NODE": Array [
-        "dummy-kentico-kontent-item-simple-landing-page-default",
+        "dummy-kentico-kontent-item-simple_landing_page-default",
       ],
       "elements": Array [
         Object {
@@ -120,7 +120,7 @@ Array [
     Object {
       "children": Array [],
       "contentItems___NODE": Array [
-        "dummy-kentico-kontent-item-main-project-default",
+        "dummy-kentico-kontent-item-main_project-default",
       ],
       "elements": Array [
         Object {
@@ -156,7 +156,7 @@ Array [
           "value": "Main project content",
         },
       },
-      "id": "dummy-kentico-kontent-item-main-project-default",
+      "id": "dummy-kentico-kontent-item-main_project-default",
       "internal": Object {
         "contentDigest": "8ace37ff9c6af66c73da31ca5bb9a991",
         "type": "KontentItemProject",
@@ -187,7 +187,7 @@ Array [
             "simple_landing_page",
           ],
           "linked_items___NODE": Array [
-            "dummy-kentico-kontent-item-simple-landing-page-default",
+            "dummy-kentico-kontent-item-simple_landing_page-default",
           ],
           "links": Array [],
           "name": "Content",
@@ -210,7 +210,7 @@ Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Duis condimentum augue
 <p><br></p>",
         },
       },
-      "id": "dummy-kentico-kontent-item-simple-landing-page-default",
+      "id": "dummy-kentico-kontent-item-simple_landing_page-default",
       "internal": Object {
         "contentDigest": "c343943a6bbcd7d749dd4ed55ec406ae",
         "type": "KontentItemLandingPage",
@@ -228,7 +228,7 @@ Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Duis condimentum augue
         "type": "landing_page",
       },
       "usedByContentItems___NODE": Array [
-        "dummy-kentico-kontent-item-simple-landing-page-default",
+        "dummy-kentico-kontent-item-simple_landing_page-default",
       ],
     },
   ],

--- a/src/__tests__/richtext-resolution/__snapshots__/type-resolvers.spec.js.snap
+++ b/src/__tests__/richtext-resolution/__snapshots__/type-resolvers.spec.js.snap
@@ -58,7 +58,7 @@ Array [
     Object {
       "children": Array [],
       "contentItems___NODE": Array [
-        "dummy-kentico-kontent-item-simple-landing-page-default",
+        "dummy-kentico-kontent-item-simple_landing_page-default",
       ],
       "elements": Array [
         Object {
@@ -87,7 +87,7 @@ Array [
     Object {
       "children": Array [],
       "contentItems___NODE": Array [
-        "dummy-kentico-kontent-item-n26ddfb46-c2de-010e-3ad9-ec9aa8955144-default",
+        "dummy-kentico-kontent-item-n26ddfb46_c2de_010e_3ad9_ec9aa8955144-default",
       ],
       "elements": Array [
         Object {
@@ -122,7 +122,7 @@ Array [
     Object {
       "children": Array [],
       "contentItems___NODE": Array [
-        "dummy-kentico-kontent-item-main-project-default",
+        "dummy-kentico-kontent-item-main_project-default",
       ],
       "elements": Array [
         Object {
@@ -158,7 +158,7 @@ Array [
           "value": "Main project content",
         },
       },
-      "id": "dummy-kentico-kontent-item-main-project-default",
+      "id": "dummy-kentico-kontent-item-main_project-default",
       "internal": Object {
         "contentDigest": "8ace37ff9c6af66c73da31ca5bb9a991",
         "type": "KontentItemProject",
@@ -176,7 +176,7 @@ Array [
         "type": "project",
       },
       "usedByContentItems___NODE": Array [
-        "dummy-kentico-kontent-item-simple-landing-page-default",
+        "dummy-kentico-kontent-item-simple_landing_page-default",
       ],
     },
   ],
@@ -200,8 +200,8 @@ Array [
             "n26ddfb46_c2de_010e_3ad9_ec9aa8955144",
           ],
           "linked_items___NODE": Array [
-            "dummy-kentico-kontent-item-main-project-default",
-            "dummy-kentico-kontent-item-n26ddfb46-c2de-010e-3ad9-ec9aa8955144-default",
+            "dummy-kentico-kontent-item-main_project-default",
+            "dummy-kentico-kontent-item-n26ddfb46_c2de_010e_3ad9_ec9aa8955144-default",
           ],
           "links": Array [
             Object {
@@ -267,7 +267,7 @@ Array [
 <object type=\\"application/kenticocloud\\" data-type=\\"item\\" data-rel=\\"link\\" data-codename=\\"main_project\\"></object>",
         },
       },
-      "id": "dummy-kentico-kontent-item-simple-landing-page-default",
+      "id": "dummy-kentico-kontent-item-simple_landing_page-default",
       "internal": Object {
         "contentDigest": "f13ad3c1ccf382fccc8700b3ae72f15a",
         "type": "KontentItemLandingPage",
@@ -358,7 +358,7 @@ Array [
           "value": "Cap",
         },
       },
-      "id": "dummy-kentico-kontent-item-n26ddfb46-c2de-010e-3ad9-ec9aa8955144-default",
+      "id": "dummy-kentico-kontent-item-n26ddfb46_c2de_010e_3ad9_ec9aa8955144-default",
       "internal": Object {
         "contentDigest": "6bec88217837aa668a48f7aa9372965c",
         "type": "KontentItemLandingPageImageSection",
@@ -376,7 +376,7 @@ Array [
         "type": "landing_page_image_section",
       },
       "usedByContentItems___NODE": Array [
-        "dummy-kentico-kontent-item-simple-landing-page-default",
+        "dummy-kentico-kontent-item-simple_landing_page-default",
       ],
     },
   ],

--- a/src/itemNodes.js
+++ b/src/itemNodes.js
@@ -1,6 +1,5 @@
 const { parse, stringify } = require(`flatted/cjs`);
 const _ = require('lodash');
-const changeCase = require('change-case');
 
 const normalize = require('./normalize');
 const validation = require('./validation');
@@ -181,16 +180,18 @@ const resolveItems = (allItems) => {
 
 /**
  * Create Gatsby generated is for content item language variant.
+ * createNodeId is a utility function useful to generate globally
+ * unique and stable node IDs. It will generate different IDs
+ * for different plugins if they use same input, therefore
+ * identificationString must be unique.
  * @param {String} itemCodename Code of the Item for creation.
  * @param {String} itemLanguage Preffered language fo the content item.
  * @param {Function} createNodeId Gatsby API method for ID creation.
  * @return {String} Gatsby node ID fot specified Llanguage variant.
  */
 const createItemNodeId = (itemCodename, itemLanguage, createNodeId) => {
-  const codename = changeCase.paramCase(itemCodename);
-  const language = changeCase.paramCase(itemLanguage);
   const prefix = 'kentico-kontent-item';
-  const identificationString = `${prefix}-${codename}-${language}`;
+  const identificationString = `${prefix}-${itemCodename}-${itemLanguage}`;
   return createNodeId(identificationString);
 };
 


### PR DESCRIPTION
### Motivation

Fixes #110 

### Checklist

- [X] Code follows coding conventions held in this repo
- [X] Automated tests have been added
- [X] Tests are passing
- [ ] Docs have been updated (if applicable)
- [X] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

If the proposed solution is applicable we should change the nodeId generating approach in the other occurrences mentioned in #110 as well and use exclusively unique codenames generated by Kontent only. 

Please consider, changing the artifact name will reflect in the breaking changes (at least) in the GraphQL queries. What do you think @Simply007?