### PR TITLE
Implement optional content property for all artifacts

### DIFF
--- a/packages/gatsby-source-kontent/README.md
+++ b/packages/gatsby-source-kontent/README.md
@@ -60,7 +60,8 @@ Since the plugin is using [Gatsby Reporter](https://www.gatsbyjs.org/docs/node-a
     "includeTaxonomies": true, // opt-out by default
     "includeTypes": true, // opt-out by default
     "usePreviewUrl": true, // false by default
-    "authorizationKey": "<API KEY>" // For preview/secured API key - depends on usePreviewUrl setting
+    "authorizationKey": "<API KEY>", // For preview/secured API key - depends on usePreviewUrl setting
+    "includeRawContent" : true // opt-out by default - include `internal.content` property in the gatsby nodes
   }
 }
 ```

--- a/packages/gatsby-source-kontent/src/sourceNodes.items.ts
+++ b/packages/gatsby-source-kontent/src/sourceNodes.items.ts
@@ -50,22 +50,24 @@ const alterRichTextElements = (items: Array<KontentItem>): void => {
 const getKontentItemLanguageVariantArtifact = (
   api: SourceNodesArgs,
   kontentItem: KontentItem,
+  includeRawContent: boolean
 ): KontentItem => {
   const nodeIdString = getKontentItemNodeStringForId(
     kontentItem.system.codename,
     kontentItem.preferred_language,
   );
-  const nodeContent = JSON.stringify(kontentItem);
   const nodeData: KontentItem = {
     ...kontentItem,
     id: api.createNodeId(nodeIdString),
     children: [],
     internal: {
       type: getKontentItemNodeTypeName(kontentItem.system.type),
-      content: nodeContent,
       contentDigest: api.createContentDigest(kontentItem),
     },
   };
+  if (includeRawContent) {
+    nodeData.internal.content = JSON.stringify(kontentItem);
+  }
   return nodeData;
 };
 
@@ -78,7 +80,7 @@ const sourceNodes = async (
     addPreferredLanguageProperty(kontentItems, language);
     alterRichTextElements(kontentItems);
     for (const kontentItem of kontentItems) {
-      const nodeData = getKontentItemLanguageVariantArtifact(api, kontentItem);
+      const nodeData = getKontentItemLanguageVariantArtifact(api, kontentItem, options.includeRawContent);
       api.actions.createNode(nodeData);
     }
   }

--- a/packages/gatsby-source-kontent/src/sourceNodes.taxonomies.ts
+++ b/packages/gatsby-source-kontent/src/sourceNodes.taxonomies.ts
@@ -9,21 +9,23 @@ import { loadAllKontentTaxonomies } from './client';
 const getKontentTypeArtifact = (
   api: SourceNodesArgs,
   kontentTaxonomy: KontentTaxonomy,
+  includeRawContent: boolean
 ): KontentTaxonomy => {
   const nodeIdString = getKontentTaxonomyNodeStringForCodeName(
     kontentTaxonomy.system.codename,
   );
-  const nodeContent = JSON.stringify(kontentTaxonomy);
   const nodeData: KontentTaxonomy = {
     ...kontentTaxonomy,
     id: api.createNodeId(nodeIdString),
     children: [],
     internal: {
       type: getKontentTaxonomyTypeName(),
-      content: nodeContent,
       contentDigest: api.createContentDigest(kontentTaxonomy),
     },
   };
+  if(includeRawContent) {
+    nodeData.internal.content = JSON.stringify(kontentTaxonomy);
+  }
   return nodeData;
 };
 
@@ -33,7 +35,7 @@ const sourceNodes = async (
 ): Promise<void> => {
   const kontentTaxonomies = await loadAllKontentTaxonomies(options);
   for (const kontentTaxonomy of kontentTaxonomies) {
-    const nodeData = getKontentTypeArtifact(api, kontentTaxonomy);
+    const nodeData = getKontentTypeArtifact(api, kontentTaxonomy, options.includeRawContent);
     api.actions.createNode(nodeData);
   }
 };

--- a/packages/gatsby-source-kontent/src/sourceNodes.types.ts
+++ b/packages/gatsby-source-kontent/src/sourceNodes.types.ts
@@ -14,21 +14,23 @@ import { loadAllKontentTypes } from './client';
 const getKontentTypeArtifact = (
   api: SourceNodesArgs,
   kontentType: KontentType,
+  includeRawContent: boolean
 ): KontentType => {
   const nodeIdString = getKontentTypeNodeStringForCodeName(
     kontentType.system.codename,
   );
-  const nodeContent = JSON.stringify(kontentType);
   const nodeData: KontentType = {
     ...kontentType,
     id: api.createNodeId(nodeIdString),
     children: [],
     internal: {
       type: getKontentTypeTypeName(),
-      content: nodeContent,
       contentDigest: api.createContentDigest(kontentType),
     },
   };
+  if(includeRawContent) {
+    nodeData.internal.content = JSON.stringify(kontentType);
+  }
   return nodeData;
 };
 
@@ -50,7 +52,7 @@ const sourceNodes = async (
   const kontentTypes = await loadAllKontentTypes(options);
   transformElementObjectToArray(kontentTypes);
   for (const kontentType of kontentTypes) {
-    const nodeData = getKontentTypeArtifact(api, kontentType);
+    const nodeData = getKontentTypeArtifact(api, kontentType, options.includeRawContent);
     api.actions.createNode(nodeData);
   }
 };

--- a/packages/gatsby-source-kontent/src/types.d.ts
+++ b/packages/gatsby-source-kontent/src/types.d.ts
@@ -14,6 +14,7 @@ interface CustomPluginOptions extends PluginOptions {
   includeTaxonomies: boolean = false;
   authorizationKey: string = null;
   usePreviewUrl: boolean = false;
+  includeRawContent: boolean = false;
 }
 
 interface CustomCreateSchemaCustomizationArgs

--- a/site/gatsby-config.js
+++ b/site/gatsby-config.js
@@ -18,6 +18,7 @@ module.exports = {
         includeTypes: true,
         // usePreviewUrl: true,
         // authorizationKey: ""
+        includeRawContent: true
       },
     },
   ],


### PR DESCRIPTION
### Motivation

Make

Ported implementation of optional `content` property. (Since [it is optional](https://www.gatsbyjs.org/docs/node-interface/#content)).

Original implementation:

 https://github.com/Kentico/gatsby-source-kontent/commit/928df87bba20263171991eb046cb1c80a17b7440