### PR TITLE
Define all possible element value shapes in typescript definition

### DIFF
--- a/packages/gatsby-source-kontent/src/types.d.ts
+++ b/packages/gatsby-source-kontent/src/types.d.ts
@@ -32,10 +32,30 @@ interface PluginNamingConfiguration {
 interface KontentItemElement {
   name: string;
   type: string;
-  value: string | number | string[];
+  value: string | number | string[] | AssetElementValue[] | MultipleChoiceOption[] | TaxonomyTerm[];
   images: { [key: string]: RichTextElementImage } | RichTextElementImage[];
   links: { [key: string]: RichTextElementLink } | RichTextElementLink[];
   modular_content: string[];
+}
+
+interface AssetElementValue {
+  name: string;
+  type: string;
+  size: number;
+  description: string;
+  url: string;
+  width?: number;
+  height?: number;
+}
+
+interface MultipleChoiceOption {
+  name: string;
+  codename: string;
+}
+
+interface TaxonomyTerm {
+  name: string;
+  codename: string;
 }
 
 interface RichTextElementImage {


### PR DESCRIPTION
### Motivation

Fixes #137 

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

There were already test for all types of elements, but since the type definition is not used in gatsby (because it is expecting `[key: string]: unknown` in their `NodeInput`) `createNode` argument, there is no clean way to cover that by test.
